### PR TITLE
Point update script at GitHub instead of Launchpad

### DIFF
--- a/update.cfg
+++ b/update.cfg
@@ -12,5 +12,5 @@ archive_base/arm64: %(archive_base/ports)s
 components: main restricted universe
 
 [bionic/vcs]
-seed_base: git+ssh://git.launchpad.net/~elementary-os/elementaryos/+git/
+seed_base: git://github.com/elementary/
 seed_dist: seeds.%(dist)s


### PR DESCRIPTION
We've migrated the `seeds` and `platform` repos off Launchpad now, so we can point this at GitHub instead. I've tested to check the update script still works and verified there aren't any outstanding changes needed to the metapackages.